### PR TITLE
BUG FIX: modify application debug flag equea options.dev

### DIFF
--- a/twork/web/server.py
+++ b/twork/web/server.py
@@ -62,7 +62,7 @@ class TApplication(tornado.web.Application):
             self._start_time), 'handler': self._handler_st}
 
     def __init__(self):
-        debug = options.env == "debug"
+        debug = options.env == "dev"
         app_settings = { 
                 'gzip': 'on',
                 'static_path': assembly.STATIC_PATH,


### PR DESCRIPTION
modify options.env equal "dev", which the default value of options.env. So that the tornado will run in debug mode as the origin idea。
